### PR TITLE
Remove "as described in the Getting Started Guide"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Setup your hardware by following the **Hardware Setup**.
 ## AVS SDK installation and Raspberry Pi audio setup
 The **Getting Started Guide** details setup steps up until this point. What follows are setup steps specific to the AVS SDK.
 
-1. Install Raspbian (Stretch) on the Raspberry Pi as described in the Getting Started Guide.
+1. Install Raspbian (Stretch) on the Raspberry Pi.
 
 2. Ensure running kernel version matches headers kernel headers package. A typical system requires the following `--reinstall` command:
 


### PR DESCRIPTION
Not present in the getting started guide