### PR TITLE
Remove I2S clock reset on avsrun

### DIFF
--- a/auto_install.sh
+++ b/auto_install.sh
@@ -91,8 +91,4 @@ if $RPI_SETUP_DIR/setup.sh xvf3510; then
   fi
 fi
 
-# Overwrite avsrun alias to ensure I2S clk is always reinitialised
-sed -i '/avsrun=/d' /home/pi/.bash_aliases > /dev/null
-echo "alias avsrun=\"sudo $RPI_SETUP_DIR/resources/clk_dac_setup/setup_bclk > /dev/null; /home/pi/sdk-folder/sdk-build/SampleApp/src/SampleApp /home/pi/sdk-folder/sdk-build/Integration/AlexaClientSDKConfig.json /home/pi/sdk-folder/third-party/alexa-rpi/models\"" >> /home/pi/.bash_aliases
-
 popd > /dev/null


### PR DESCRIPTION
Resetting the clocks is no longer needed - I2S clocks are set correctly at boot and when audacity starts up.